### PR TITLE
Feature/config shortcuts

### DIFF
--- a/rsr/app.py
+++ b/rsr/app.py
@@ -6,7 +6,6 @@ import xdg.BaseDirectory
 from gi.repository import Gio, Gtk
 
 from rsr import config
-from rsr.commands import commands
 from rsr.connections.manager import ConnectionManager
 from rsr.mainwin import MainWindow
 from rsr.preferences import PreferencesDialog
@@ -93,6 +92,7 @@ class Application(Gtk.Application):
         self.on_use_dark_theme()
         self.action_groups = {}
         accel_group = Gtk.AccelGroup()
+        commands = self.config.get_commands()
         for group_key in commands:
             group = Gio.SimpleActionGroup()
             self.action_groups[group_key] = group

--- a/rsr/config.py
+++ b/rsr/config.py
@@ -46,11 +46,9 @@ class Config(GObject.GObject):
 
     def get_commands(self):
         result = copy.deepcopy(commands)
-        print(result)
         for cat, shortcuts in self.shortcuts.items():
             for command, shortcut in shortcuts.items():
                 result[cat]['actions'][command]['shortcut'] = shortcut
-        print(result)
         return result
 
     def save(self):

--- a/rsr/config.py
+++ b/rsr/config.py
@@ -1,11 +1,14 @@
 import json
 import os
+import copy
 
 from gi.repository import GObject, Gio
 from xdg import BaseDirectory
+from rsr.commands import commands
 
 CONFIG_FILE = os.path.join(BaseDirectory.save_config_path('runsqlrun'),
                            'config.json')
+default_keys = lambda c: {k:v['shortcut'] for k,v in commands[c]['actions'].items()}
 
 name = 'runsqlrun'
 version = '0.4.2-dev0'
@@ -24,6 +27,7 @@ class Config(GObject.GObject):
     font_fontname = GObject.Property(type=str, default='Monospace 13')
     editor_tab_width = GObject.Property(type=int, default=2)
     editor_show_line_numbers = GObject.Property(type=bool, default=True)
+    shortcuts = {'app':default_keys('app'), 'editor':default_keys('editor')}
 
     def __init__(self):
         GObject.GObject.__init__(self)
@@ -40,12 +44,23 @@ class Config(GObject.GObject):
         else:
             return self.font_fontname
 
+    def get_commands(self):
+        result = copy.deepcopy(commands)
+        print(result)
+        for cat, shortcuts in self.shortcuts.items():
+            for command, shortcut in shortcuts.items():
+                result[cat]['actions'][command]['shortcut'] = shortcut
+        print(result)
+        return result
+
     def save(self):
         data = {}
         for gspec in self.list_properties():
             data[gspec.name] = self.get_property(gspec.name)
+        for cat in self.shortcuts:
+            data['shortcuts_%s' % cat] = self.shortcuts[cat]
         with open(CONFIG_FILE, 'w') as f:
-            json.dump(data, f)
+            json.dump(data, f, indent=2, sort_keys=True)
 
 
 def load():
@@ -57,4 +72,8 @@ def load():
     for gspec in conf.list_properties():
         if gspec.name in data:
             conf.set_property(gspec.name, data[gspec.name])
+    for cat in conf.shortcuts:
+        name = 'shortcuts_%s' % cat
+        if name in data:
+            conf.shortcuts[cat] = data[name]
     return conf

--- a/rsr/headerbar.py
+++ b/rsr/headerbar.py
@@ -2,7 +2,6 @@ from gi.repository import Gio, Gtk
 from gi.repository.GdkPixbuf import Pixbuf
 
 from rsr import __version__
-from rsr.commands import commands
 from rsr.connections.ui import ConnectionDialog
 
 
@@ -42,6 +41,7 @@ class HeaderBar(Gtk.HeaderBar):
     def _btn_from_command(self, group, name):
         btn = Gtk.Button()
         btn.set_action_name('app.{}_{}'.format(group, name))
+        commands = self.win.app.config.get_commands()
         data = commands[group]['actions'][name]
         icon = Gio.ThemedIcon(name=data['icon'])
         image = Gtk.Image.new_from_gicon(icon, Gtk.IconSize.BUTTON)


### PR DESCRIPTION
This adds shortcuts to the config.json with the keys `shortcuts_app` and `shortcuts_editor`. A few things to note:

* I was not able to make proper `GObject.Property` objects in the Config class. It was complaining about the dict type.
* I did not error check shortcut strings as valid key combinations.
* If a shortcut is edited within the app, the shortcuts displayed on button tooltips may not updated until the next time rsr starts.

Bonus: I made the config.json file a bit more human readable with indent and sorting.